### PR TITLE
NCurses interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,15 @@ if(READLINE_LIB)
   target_link_libraries(aeolus PRIVATE ${READLINE_LIB})
 endif()
 
+# ncurses (optional, for ncurses TUI)
+find_package(Curses)
+if(CURSES_FOUND)
+  target_compile_definitions(aeolus PRIVATE HAVE_NIFACE)
+  target_sources(aeolus PRIVATE source/niface.cc)
+  target_include_directories(aeolus PRIVATE ${CURSES_INCLUDE_DIR})
+  target_link_libraries(aeolus PRIVATE ${CURSES_LIBRARIES})
+endif()
+
 # Optional unit tests
 pkg_check_modules(GMOCK gmock)
 option(BUILD_TESTS "Build unit tests" ${GMOCK_FOUND})

--- a/doc/Terminal_Interface.md
+++ b/doc/Terminal_Interface.md
@@ -1,0 +1,57 @@
+# Aeolus Terminal Interface
+
+## Overview
+
+The Aeolus terminal interface provides a text-based console interface for controlling the organ synthesizer. It displays organ stops in a grid layout and allows keyboard navigation and control.
+
+## Screen Layout
+
+The interface displays:
+- Title Bar: Shows the current instrument name
+- Group Columns: Organ divisions (keyboards) arranged in columns
+- Stop Lists: Individual stops within each group
+- Cursor: A ">" symbol showing your current position
+- Status Line: Shows available controls and current state
+
+## Visual Indicators
+
+- Normal stops: White text
+- Tremulants: Green text (if colors supported)
+- Couplers: Yellow text (if colors supported)
+- Active stops: Highlighted in reverse video
+- Tuning stops: Blinking text during retuning
+
+## Controls
+
+### Navigation
+- Arrow Keys: Move cursor between stops
+  - Up/Down: Navigate within group or move between groups
+  - Left/Right: Move between groups
+
+### Stop Control
+- Space: Toggle current stop on/off
+- 0 or `: General cancel (turn off all stops)
+
+### Presets
+- 1-9: Recall preset 1-9
+- Shift+1-9: Store current registration as preset 1-9
+
+### Commands
+- /: Enter command mode
+- quit: Exit program (type after pressing /)
+- Ctrl-D: Quit immediately
+
+## Getting Started
+
+1. Launch Aeolus with the terminal interface option
+2. Wait for "Aeolus is ready" message in the status line
+3. Use arrow keys to navigate between stops
+4. Press Space to toggle stops on/off
+5. Use number keys to recall saved presets
+
+## Tips
+
+- The interface automatically adjusts to your terminal size
+- Controls are disabled during initial loading and tuning
+- The cursor wraps between groups when reaching boundaries
+- All changes are heard immediately through the audio output

--- a/source/main.cc
+++ b/source/main.cc
@@ -33,6 +33,9 @@
 #if defined(STATIC_UI) && defined(HAVE_XIFACE)
 #include "xiface.h"
 #endif
+#if defined(STATIC_UI) && defined(HAVE_NIFACE)
+#include "niface.h"
+#endif
 #include "global.h"
 #include "audio_factory.h"
 #ifdef __linux__
@@ -45,13 +48,14 @@
 
 
 #ifdef __linux__
-static const char *options = "htuAJBM:N:S:I:W:d:r:p:n:s:";
+static const char *options = "htuAJBcM:N:S:I:W:d:r:p:n:s:";
 #else
-static const char *options = "htuJBM:N:S:I:W:s:";
+static const char *options = "htuJBcM:N:S:I:W:s:";
 #endif
 static char  optline [1024];
 static bool  t_opt = false;
 static bool  u_opt = false;
+static bool  c_opt = false;
 static bool  A_opt = false;
 static bool  B_opt = false;
 static int   r_val = 48000;
@@ -76,6 +80,7 @@ static void help (void)
     fprintf (stderr, "Options:\n");
     fprintf (stderr, "  -h                 Display this text\n");
     fprintf (stderr, "  -t                 Text mode user interface\n");
+    fprintf (stderr, "  -c                 NCurses mode user interface\n");
     fprintf (stderr, "  -u                 Use presets file in user's home dir\n");
     fprintf (stderr, "  -N <name>          Name to use as JACK and ALSA client [aeolus]\n");
     fprintf (stderr, "  -S <stops>         Name of stops directory [stops]\n");
@@ -114,6 +119,7 @@ static void procoptions (int ac, char *av [], const char *where)
         {
         case 'h' : help (); exit (0);
          case 't' : t_opt = true;  break;
+         case 'c' : c_opt = true;  break;
          case 'u' : u_opt = true;  break;
          case 'A' : A_opt = true;  break;
         case 'J' : A_opt = false; break;
@@ -209,6 +215,15 @@ int main (int ac, char *av [])
         iface = new Tiface (ac, av);
 #else
         fprintf (stderr, "Error: text interface not available in this build.\n");
+        return 1;
+#endif
+    }
+    else if (c_opt)
+    {
+#ifdef HAVE_NIFACE
+        iface = new Niface (ac, av);
+#else
+        fprintf (stderr, "Error: NCurses interface not available in this build.\n");
         return 1;
 #endif
     }

--- a/source/messages.h
+++ b/source/messages.h
@@ -44,6 +44,8 @@ enum
     EV_RLINE = 0,
     EV_XWIN  = 16,
     EV_QMIDI = 24,
+    EV_REDRAW = 28,
+    EV_INPUT = 29, 
     EV_SYNC  = 30,
     EV_EXIT  = 31
 };

--- a/source/niface.cc
+++ b/source/niface.cc
@@ -34,10 +34,45 @@ extern "C" Iface *create_iface (int ac, char *av [])
 #endif
 
 
+NITCHandler::NITCHandler (Niface *niface) :
+    H_thread (niface, EV_EXIT),
+    _niface (niface)
+{
+}
+
+
+NITCHandler::~NITCHandler (void)
+{
+}
+
+
+void NITCHandler::thr_main (void)
+{
+    // This thread handles ITC events from the model
+    _niface->set_time (0);
+    _niface->inc_time (125000);
+
+    while (true)
+    {
+        switch (_niface->get_event ())
+        {
+        case FM_MODEL:
+            _niface->handle_mesg (_niface->get_message ());
+            break;
+
+        case EV_EXIT:
+            _niface->_stop = true;
+            return;
+        }
+    }
+}
+
+
 Niface::Niface (int ac, char *av []) :
     _stop (false),
     _init (true),
     _command_mode (false),
+    _need_redraw (false),
     _initdata (0),
     _mididata (0),
     _main_win (0),
@@ -48,12 +83,17 @@ Niface::Niface (int ac, char *av []) :
     _max_cols (0),
     _groups_per_row (1),
     _group_width (20),
-    _command_pos (0)
+    _command_pos (0),
+    _itc_handler (0)
 {
     int i;
 
     for (i = 0; i < NGROUP; i++) _ifelms [i] = 0;
     _command_buffer[0] = 0;
+    
+    // Create ITC handler thread
+    _itc_handler = new NITCHandler (this);
+    
     init_ncurses ();
 }
 
@@ -61,6 +101,7 @@ Niface::Niface (int ac, char *av []) :
 Niface::~Niface (void)
 {
     cleanup_ncurses ();
+    if (_itc_handler) delete _itc_handler;
 }
 
 
@@ -90,7 +131,8 @@ void Niface::init_ncurses (void)
     cbreak ();       // Disable line buffering
     noecho ();       // Don't echo input
     keypad (stdscr, TRUE);  // Enable function keys
-    nodelay (stdscr, TRUE); // Non-blocking input
+    nodelay (stdscr, FALSE); // Enable blocking getch()
+    // No timeout needed for blocking input
     curs_set (0);    // Hide cursor
     
     // Get screen dimensions
@@ -100,9 +142,17 @@ void Niface::init_ncurses (void)
     _main_win = newwin (_max_rows - 1, _max_cols, 0, 0);
     _status_win = newwin (1, _max_cols, _max_rows - 1, 0);
     
+    // Set reasonable defaults for layout before data arrives
+    _group_width = 24;  // Wider to accommodate full stop names
+    _groups_per_row = _max_cols / _group_width;
+    if (_groups_per_row < 1) _groups_per_row = 1;
+    
     // Set up signal handler for clean shutdown
     signal (SIGINT, SIG_IGN);
     signal (SIGTERM, SIG_IGN);
+    
+    // Show initial interface immediately
+    draw_screen ();
 }
 
 
@@ -116,35 +166,51 @@ void Niface::cleanup_ncurses (void)
 
 void Niface::thr_main (void)
 {
-    set_time (0);
-    inc_time (125000);
-
+    // Start the ITC handler thread
+    _itc_handler->thr_start (SCHED_OTHER, 0, 0);
+    
+    // Main NCurses loop - handle input and display only
     while (! _stop)
     {
-        switch (get_event ())
+        // Handle keyboard input - this will block until a key is pressed
+        int ch = getch ();
+        if (ch != ERR)
         {
-        case FM_MODEL:
-            handle_mesg (get_message ());
-            break;
-
-        case EV_EXIT:
-            return;
-            
-        default:
-            handle_input ();
-            break;
+            handle_key (ch);
         }
+        
+        // Redraw screen after input or when needed
+        if (_need_redraw)
+        {
+            _need_redraw = false;
+        }
+        draw_screen ();
     }
-    send_event (EV_EXIT, 1);
 }
 
 
-void Niface::handle_input (void)
+void Niface::handle_input_msg (void)
 {
-    int ch = getch ();
+    M_ifc_txtip *M = (M_ifc_txtip *) get_message ();
     
-    if (ch == ERR) return;  // No input available
+    if (!M->_line) 
+    {
+        M->recover ();
+        return;
+    }
     
+    int ch = M->_line[0];
+    delete[] M->_line;
+    M->recover ();
+    
+    handle_key (ch);
+}
+
+
+
+
+void Niface::handle_key (int ch)
+{
     if (_command_mode)
     {
         switch (ch)
@@ -156,6 +222,7 @@ void Niface::handle_input (void)
             {
                 if (strcmp (_command_buffer, "quit") == 0)
                 {
+                    _stop = true;
                     send_event (EV_EXIT, 1);
                     return;
                 }
@@ -192,7 +259,9 @@ void Niface::handle_input (void)
     // Normal mode key handling
     switch (ch)
     {
-    case 4:  // Ctrl-D
+    case 4:   // Ctrl-D (EOT)
+    case EOF: // EOF (also Ctrl-D in some cases)
+        _stop = true;
         send_event (EV_EXIT, 1);
         break;
         
@@ -257,35 +326,53 @@ void Niface::enter_command_mode (void)
 
 void Niface::handle_resize (void)
 {
-    endwin ();
-    refresh ();
-    getmaxyx (stdscr, _max_rows, _max_cols);
-    
-    if (_main_win) delwin (_main_win);
-    if (_status_win) delwin (_status_win);
-    
-    _main_win = newwin (_max_rows - 1, _max_cols, 0, 0);
-    _status_win = newwin (1, _max_cols, _max_rows - 1, 0);
-    
-    calculate_layout ();
+    // The dynamic resize checking in draw_screen() should handle this
+    // Just force a screen redraw
     draw_screen ();
 }
 
 
 void Niface::calculate_layout (void)
 {
-    if (!_initdata) return;
-    
-    // Simple layout: calculate groups per row based on screen width
-    _group_width = 20;  // Each group needs about 20 characters
+    // Calculate optimal group layout based on screen size
+    _group_width = 24;  // Each group needs about 24 characters for full stop names
     _groups_per_row = _max_cols / _group_width;
     if (_groups_per_row < 1) _groups_per_row = 1;
+    
+    // If we have init data, refine the layout based on actual group count
+    if (_initdata)
+    {
+        // Ensure we don't exceed available groups
+        if (_groups_per_row > _initdata->_ngroup) 
+            _groups_per_row = _initdata->_ngroup;
+    }
+    
+    // Adjust group width to use full screen width
+    if (_groups_per_row > 1)
+        _group_width = _max_cols / _groups_per_row;
 }
 
 
 void Niface::draw_screen (void)
 {
     if (!_main_win || !_status_win) return;
+    
+    // Always check current screen dimensions before drawing
+    int current_rows, current_cols;
+    getmaxyx (stdscr, current_rows, current_cols);
+    
+    // Update layout if dimensions changed
+    if (current_rows != _max_rows || current_cols != _max_cols)
+    {
+        _max_rows = current_rows;
+        _max_cols = current_cols;
+        calculate_layout ();
+        
+        // Resize windows to match new dimensions
+        wresize (_main_win, _max_rows - 1, _max_cols);
+        wresize (_status_win, 1, _max_cols);
+        mvwin (_status_win, _max_rows - 1, 0);
+    }
     
     werase (_main_win);
     werase (_status_win);
@@ -301,20 +388,103 @@ void Niface::draw_screen (void)
 
 void Niface::draw_groups (void)
 {
-    if (!_initdata) return;
+    if (!_initdata) 
+    {
+        // Show loading message before instrument data arrives
+        mvwprintw (_main_win, 0, 1, "Aeolus NCurses Interface");
+        mvwprintw (_main_win, 2, 1, "Loading instrument data...");
+        return;
+    }
     
-    // TODO: Implement group drawing - placeholder for now
-    mvwprintw (_main_win, 1, 1, "Aeolus NCurses Interface");
-    mvwprintw (_main_win, 2, 1, "Groups will be displayed here");
+    int row = 1, col = 1;
+    int group_start_row = 2;
+    
+    // Title
+    mvwprintw (_main_win, 0, 1, "Aeolus NCurses Interface - %s", _initdata->_instrdir);
+    
+    // Draw each group
+    for (int g = 0; g < _initdata->_ngroup; g++)
+    {
+        // Calculate group position
+        int group_col = col + (g % _groups_per_row) * _group_width;
+        int group_row = group_start_row + (g / _groups_per_row) * 15; // 15 lines per group max
+        
+        if (group_row >= _max_rows - 2) break; // Don't overflow screen
+        
+        // Group header with rewritten label
+        char group_label[32];
+        rewrite_label (_initdata->_groupd[g]._label, group_label, sizeof(group_label));
+        
+        // Use color for group header
+        if (has_colors ()) wattron (_main_win, COLOR_PAIR(4) | A_BOLD);
+        mvwprintw (_main_win, group_row, group_col, "%s", group_label);
+        if (has_colors ()) wattroff (_main_win, COLOR_PAIR(4) | A_BOLD);
+        
+        // Draw stops in this group
+        for (int i = 0; i < _initdata->_groupd[g]._nifelm; i++)
+        {
+            int stop_row = group_row + 1 + i;
+            if (stop_row >= _max_rows - 1) break; // Don't overflow
+            
+            // Check if this stop is pulled (active)
+            bool is_pulled = (_ifelms[g] & (1 << i)) != 0;
+            
+            // Get stop color based on type
+            int color_pair = get_stop_color (g, i);
+            
+            // Apply highlighting for pulled stops
+            if (has_colors ())
+            {
+                if (is_pulled)
+                    wattron (_main_win, COLOR_PAIR(color_pair) | A_REVERSE | A_BOLD);
+                else
+                    wattron (_main_win, COLOR_PAIR(color_pair));
+            }
+            else
+            {
+                if (is_pulled)
+                    wattron (_main_win, A_REVERSE | A_BOLD);
+            }
+            
+            // Draw the stop with its full label (rewritten to remove $)
+            char stop_label[32];
+            rewrite_label (_initdata->_groupd[g]._ifelmd[i]._label, stop_label, sizeof(stop_label));
+            mvwprintw (_main_win, stop_row, group_col + 1, "%-16s", stop_label);
+            
+            // Turn off attributes
+            if (has_colors ())
+            {
+                if (is_pulled)
+                    wattroff (_main_win, COLOR_PAIR(color_pair) | A_REVERSE | A_BOLD);
+                else
+                    wattroff (_main_win, COLOR_PAIR(color_pair));
+            }
+            else
+            {
+                if (is_pulled)
+                    wattroff (_main_win, A_REVERSE | A_BOLD);
+            }
+        }
+    }
 }
 
 
 void Niface::draw_cursor (void)
 {
-    if (!_initdata) return;
+    if (!_initdata || _cursor_group >= _initdata->_ngroup) return;
     
-    // TODO: Implement cursor drawing
-    mvwprintw (_main_win, 4, 1, "Cursor: Group %d, Stop %d", _cursor_group, _cursor_ifelm);
+    // Calculate cursor position on screen
+    int cursor_y, cursor_x;
+    get_stop_position (_cursor_group, _cursor_ifelm, &cursor_y, &cursor_x);
+    
+    // Draw cursor indicator - a simple > character
+    if (cursor_y > 0 && cursor_y < _max_rows - 1 && 
+        cursor_x > 0 && cursor_x < _max_cols - 1)
+    {
+        if (has_colors ()) wattron (_main_win, COLOR_PAIR(3));
+        mvwprintw (_main_win, cursor_y, cursor_x - 1, ">");
+        if (has_colors ()) wattroff (_main_win, COLOR_PAIR(3));
+    }
 }
 
 
@@ -333,26 +503,92 @@ void Niface::draw_status (void)
 
 void Niface::move_cursor (int dy, int dx)
 {
-    // TODO: Implement proper cursor movement with bounds checking
+    if (!_initdata) return;
+    
+    // Handle vertical movement within a group
+    if (dy != 0)
+    {
+        int new_ifelm = _cursor_ifelm + dy;
+        
+        // Check bounds within current group
+        if (new_ifelm >= 0 && new_ifelm < _initdata->_groupd[_cursor_group]._nifelm)
+        {
+            _cursor_ifelm = new_ifelm;
+        }
+        else if (dy > 0) // Moving down, wrap to next group
+        {
+            if (_cursor_group + 1 < _initdata->_ngroup)
+            {
+                _cursor_group++;
+                _cursor_ifelm = 0;
+            }
+        }
+        else // Moving up, wrap to previous group
+        {
+            if (_cursor_group > 0)
+            {
+                _cursor_group--;
+                _cursor_ifelm = _initdata->_groupd[_cursor_group]._nifelm - 1;
+            }
+        }
+    }
+    
+    // Handle horizontal movement between groups
+    if (dx != 0)
+    {
+        int new_group = _cursor_group + dx;
+        
+        // Check bounds for group
+        if (new_group >= 0 && new_group < _initdata->_ngroup)
+        {
+            _cursor_group = new_group;
+            // Ensure cursor ifelm is within new group bounds
+            if (_cursor_ifelm >= _initdata->_groupd[_cursor_group]._nifelm)
+            {
+                _cursor_ifelm = _initdata->_groupd[_cursor_group]._nifelm - 1;
+            }
+        }
+    }
+    
     draw_screen ();
 }
 
 
 void Niface::toggle_current_stop (void)
 {
-    // TODO: Implement stop toggling
+    if (!_initdata || _cursor_group >= _initdata->_ngroup) return;
+    if (_cursor_ifelm >= _initdata->_groupd[_cursor_group]._nifelm) return;
+    
+    // Send button toggle message to model
+    M_ifc_ifelm *M = new M_ifc_ifelm (MT_IFC_ELXOR, _cursor_group, _cursor_ifelm);
+    send_event (TO_MODEL, M);
+    
+    draw_screen ();
 }
 
 
 void Niface::recall_preset (int preset)
 {
-    // TODO: Implement preset recall
+    if (preset < 1 || preset > 9) return;
+    
+    // Send preset recall message to model
+    M_ifc_preset *M = new M_ifc_preset (MT_IFC_PRRCL, 0, preset - 1, 0, 0);
+    send_event (TO_MODEL, M);
+    
+    draw_screen ();
 }
 
 
 void Niface::store_preset (int preset)
 {
-    // TODO: Implement preset storage
+    if (preset < 1 || preset > 9) return;
+    
+    // Send preset store message to model - need current state bits
+    // For now, just send with null bits - model will handle current state
+    M_ifc_preset *M = new M_ifc_preset (MT_IFC_PRSTO, 0, preset - 1, 0, 0);
+    send_event (TO_MODEL, M);
+    
+    draw_screen ();
 }
 
 
@@ -420,8 +656,11 @@ void Niface::handle_ifc_ready (void)
 {
     if (_init)
     {
-        calculate_layout ();
+        // Don't recalculate layout - keep the one we already established
+        // Just redraw the screen with the new instrument data
         draw_screen ();
+        
+        // Interface is now ready for input
     }
     _init = false;
 }
@@ -457,14 +696,14 @@ void Niface::handle_ifc_grclr (M_ifc_ifelm *M)
 void Niface::handle_ifc_elclr (M_ifc_ifelm *M)
 {
     _ifelms [M->_group] &= ~(1 << M->_ifelm);
-    draw_screen ();
+    _need_redraw = true;
 }
 
 
 void Niface::handle_ifc_elset (M_ifc_ifelm *M)
 {
     _ifelms [M->_group] |= (1 << M->_ifelm);
-    draw_screen ();
+    _need_redraw = true;
 }
 
 
@@ -497,16 +736,36 @@ int Niface::get_stop_color (int group, int ifelm)
     if (ifelm >= _initdata->_groupd[group]._nifelm) return 4;
     
     int type = _initdata->_groupd[group]._ifelmd[ifelm]._type;
+    const char *label = _initdata->_groupd[group]._ifelmd[ifelm]._label;
+    const char *mnemo = _initdata->_groupd[group]._ifelmd[ifelm]._mnemo;
     
-    // Color coding based on stop type
-    // TODO: Define proper type constants
+    // Use _type first, then fallback to name matching
     switch (type)
     {
-    case 1:  // Tremulant
+    case 0:  // Normal stops
+        return 4;  // Normal white
+    case 1:  // Tremulants 
         return 1;  // Green
-    case 2:  // Coupler
-        return 2;  // Yellow/Brown
+    case 2:  // Couplers
+        return 2;  // Yellow
     default:
+        // Fallback to name-based detection
+        if (strstr(label, "Tremulant") || strstr(label, "tremulant") ||
+            strstr(mnemo, "trem") || strstr(mnemo, "Trem"))
+        {
+            return 1;  // Green
+        }
+        
+        if (strstr(label, "Coupler") || strstr(label, "coupler") ||
+            strstr(mnemo, "coup") || strstr(mnemo, "Coup") ||
+            strstr(label, " II") || strstr(label, " III") ||
+            strstr(label, " P") || strstr(label, "Ped") ||
+            strstr(mnemo, "II") || strstr(mnemo, "III") ||
+            strstr(mnemo, "P") || strstr(mnemo, "Ped"))
+        {
+            return 2;  // Yellow
+        }
+        
         return 4;  // Normal white
     }
 }
@@ -514,7 +773,10 @@ int Niface::get_stop_color (int group, int ifelm)
 
 void Niface::get_stop_position (int group, int ifelm, int *y, int *x)
 {
-    // TODO: Calculate proper screen positions based on layout
-    *y = 5 + ifelm;
-    *x = 1 + (group % _groups_per_row) * _group_width;
+    int group_start_row = 2;
+    int group_col = 1 + (group % _groups_per_row) * _group_width;
+    int group_row = group_start_row + (group / _groups_per_row) * 15;
+    
+    *y = group_row + 1 + ifelm; // +1 for group header
+    *x = group_col + 1; // +1 to align with stop text
 }

--- a/source/niface.cc
+++ b/source/niface.cc
@@ -1,0 +1,520 @@
+// ----------------------------------------------------------------------------
+//
+//  Copyright (C) 2003-2022 Fons Adriaensen <fons@linuxaudio.org>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <signal.h>
+#include "niface.h"
+
+
+#ifndef STATIC_UI
+extern "C" Iface *create_iface (int ac, char *av [])
+{
+    return new Niface (ac, av);
+}
+#endif
+
+
+Niface::Niface (int ac, char *av []) :
+    _stop (false),
+    _init (true),
+    _command_mode (false),
+    _initdata (0),
+    _mididata (0),
+    _main_win (0),
+    _status_win (0),
+    _cursor_group (0),
+    _cursor_ifelm (0),
+    _max_rows (0),
+    _max_cols (0),
+    _groups_per_row (1),
+    _group_width (20),
+    _command_pos (0)
+{
+    int i;
+
+    for (i = 0; i < NGROUP; i++) _ifelms [i] = 0;
+    _command_buffer[0] = 0;
+    init_ncurses ();
+}
+
+
+Niface::~Niface (void)
+{
+    cleanup_ncurses ();
+}
+
+
+void Niface::stop (void)
+{
+    _stop = true;
+}
+
+
+void Niface::init_ncurses (void)
+{
+    // Initialize ncurses
+    initscr ();
+    
+    // Enable color if available
+    if (has_colors ())
+    {
+        start_color ();
+        // Define color pairs
+        init_pair (1, COLOR_GREEN, COLOR_BLACK);   // Tremulants
+        init_pair (2, COLOR_YELLOW, COLOR_BLACK);  // Couplers  
+        init_pair (3, COLOR_BLACK, COLOR_WHITE);   // Cursor
+        init_pair (4, COLOR_WHITE, COLOR_BLACK);   // Normal
+    }
+    
+    // Configure terminal
+    cbreak ();       // Disable line buffering
+    noecho ();       // Don't echo input
+    keypad (stdscr, TRUE);  // Enable function keys
+    nodelay (stdscr, TRUE); // Non-blocking input
+    curs_set (0);    // Hide cursor
+    
+    // Get screen dimensions
+    getmaxyx (stdscr, _max_rows, _max_cols);
+    
+    // Create windows
+    _main_win = newwin (_max_rows - 1, _max_cols, 0, 0);
+    _status_win = newwin (1, _max_cols, _max_rows - 1, 0);
+    
+    // Set up signal handler for clean shutdown
+    signal (SIGINT, SIG_IGN);
+    signal (SIGTERM, SIG_IGN);
+}
+
+
+void Niface::cleanup_ncurses (void)
+{
+    if (_main_win) delwin (_main_win);
+    if (_status_win) delwin (_status_win);
+    endwin ();
+}
+
+
+void Niface::thr_main (void)
+{
+    set_time (0);
+    inc_time (125000);
+
+    while (! _stop)
+    {
+        switch (get_event ())
+        {
+        case FM_MODEL:
+            handle_mesg (get_message ());
+            break;
+
+        case EV_EXIT:
+            return;
+            
+        default:
+            handle_input ();
+            break;
+        }
+    }
+    send_event (EV_EXIT, 1);
+}
+
+
+void Niface::handle_input (void)
+{
+    int ch = getch ();
+    
+    if (ch == ERR) return;  // No input available
+    
+    if (_command_mode)
+    {
+        switch (ch)
+        {
+        case 27:  // ESC
+        case '\n':
+        case '\r':
+            if (ch == '\n' || ch == '\r')
+            {
+                if (strcmp (_command_buffer, "quit") == 0)
+                {
+                    send_event (EV_EXIT, 1);
+                    return;
+                }
+            }
+            _command_mode = false;
+            _command_pos = 0;
+            _command_buffer[0] = 0;
+            draw_screen ();
+            break;
+            
+        case KEY_BACKSPACE:
+        case 127:
+        case 8:
+            if (_command_pos > 0)
+            {
+                _command_pos--;
+                _command_buffer[_command_pos] = 0;
+                draw_screen ();
+            }
+            break;
+            
+        default:
+            if (isprint (ch) && _command_pos < sizeof(_command_buffer) - 1)
+            {
+                _command_buffer[_command_pos++] = ch;
+                _command_buffer[_command_pos] = 0;
+                draw_screen ();
+            }
+            break;
+        }
+        return;
+    }
+    
+    // Normal mode key handling
+    switch (ch)
+    {
+    case 4:  // Ctrl-D
+        send_event (EV_EXIT, 1);
+        break;
+        
+    case '/':
+        enter_command_mode ();
+        break;
+        
+    case KEY_UP:
+        move_cursor (-1, 0);
+        break;
+        
+    case KEY_DOWN:
+        move_cursor (1, 0);
+        break;
+        
+    case KEY_LEFT:
+        move_cursor (0, -1);
+        break;
+        
+    case KEY_RIGHT:
+        move_cursor (0, 1);
+        break;
+        
+    case ' ':
+        toggle_current_stop ();
+        break;
+        
+    case '0':
+    case '`':
+        general_cancel ();
+        break;
+        
+    case '1': case '2': case '3': case '4': case '5':
+    case '6': case '7': case '8': case '9':
+        recall_preset (ch - '0');
+        break;
+        
+    case '!': case '@': case '#': case '$': case '%':
+    case '^': case '&': case '*': case '(':
+        {
+            const char *shift_keys = "!@#$%^&*(";
+            const char *pos = strchr (shift_keys, ch);
+            if (pos) store_preset (pos - shift_keys + 1);
+        }
+        break;
+        
+    case KEY_RESIZE:
+        handle_resize ();
+        break;
+    }
+}
+
+
+void Niface::enter_command_mode (void)
+{
+    _command_mode = true;
+    _command_pos = 0;
+    _command_buffer[0] = 0;
+    draw_screen ();
+}
+
+
+void Niface::handle_resize (void)
+{
+    endwin ();
+    refresh ();
+    getmaxyx (stdscr, _max_rows, _max_cols);
+    
+    if (_main_win) delwin (_main_win);
+    if (_status_win) delwin (_status_win);
+    
+    _main_win = newwin (_max_rows - 1, _max_cols, 0, 0);
+    _status_win = newwin (1, _max_cols, _max_rows - 1, 0);
+    
+    calculate_layout ();
+    draw_screen ();
+}
+
+
+void Niface::calculate_layout (void)
+{
+    if (!_initdata) return;
+    
+    // Simple layout: calculate groups per row based on screen width
+    _group_width = 20;  // Each group needs about 20 characters
+    _groups_per_row = _max_cols / _group_width;
+    if (_groups_per_row < 1) _groups_per_row = 1;
+}
+
+
+void Niface::draw_screen (void)
+{
+    if (!_main_win || !_status_win) return;
+    
+    werase (_main_win);
+    werase (_status_win);
+    
+    draw_groups ();
+    draw_cursor ();
+    draw_status ();
+    
+    wrefresh (_main_win);
+    wrefresh (_status_win);
+}
+
+
+void Niface::draw_groups (void)
+{
+    if (!_initdata) return;
+    
+    // TODO: Implement group drawing - placeholder for now
+    mvwprintw (_main_win, 1, 1, "Aeolus NCurses Interface");
+    mvwprintw (_main_win, 2, 1, "Groups will be displayed here");
+}
+
+
+void Niface::draw_cursor (void)
+{
+    if (!_initdata) return;
+    
+    // TODO: Implement cursor drawing
+    mvwprintw (_main_win, 4, 1, "Cursor: Group %d, Stop %d", _cursor_group, _cursor_ifelm);
+}
+
+
+void Niface::draw_status (void)
+{
+    if (_command_mode)
+    {
+        mvwprintw (_status_win, 0, 0, "/%s", _command_buffer);
+    }
+    else
+    {
+        mvwprintw (_status_win, 0, 0, "Arrow keys:move, Space:toggle, 1-9:presets, /:command, Ctrl-D:quit");
+    }
+}
+
+
+void Niface::move_cursor (int dy, int dx)
+{
+    // TODO: Implement proper cursor movement with bounds checking
+    draw_screen ();
+}
+
+
+void Niface::toggle_current_stop (void)
+{
+    // TODO: Implement stop toggling
+}
+
+
+void Niface::recall_preset (int preset)
+{
+    // TODO: Implement preset recall
+}
+
+
+void Niface::store_preset (int preset)
+{
+    // TODO: Implement preset storage
+}
+
+
+void Niface::general_cancel (void)
+{
+    // TODO: Implement general cancel (push all stops)
+}
+
+
+void Niface::handle_mesg (ITC_mesg *M)
+{
+    switch (M->type ())
+    {
+    case MT_IFC_INIT:
+        handle_ifc_init ((M_ifc_init *) M);
+        M = 0;
+        break;
+
+    case MT_IFC_READY:
+        handle_ifc_ready ();
+        break;
+
+    case MT_IFC_ELCLR:
+        handle_ifc_elclr ((M_ifc_ifelm *) M);
+        break;
+
+    case MT_IFC_ELSET:
+        handle_ifc_elset ((M_ifc_ifelm *) M);
+        break;
+
+    case MT_IFC_ELATT:
+        handle_ifc_elatt ((M_ifc_ifelm *) M);
+        break;
+
+    case MT_IFC_GRCLR:
+        handle_ifc_grclr ((M_ifc_ifelm *) M);
+        break;
+
+    case MT_IFC_AUPAR:
+        break;
+
+    case MT_IFC_DIPAR:
+        break;
+
+    case MT_IFC_RETUNE:
+        handle_ifc_retune ((M_ifc_retune *) M);
+        break;
+
+    case MT_IFC_MCSET:
+        handle_ifc_mcset ((M_ifc_chconf *) M);
+        M = 0;
+        break;
+
+    case MT_IFC_PRRCL:
+        break;
+
+    default:
+        break;
+    }
+    if (M) M->recover ();
+}
+
+
+void Niface::handle_ifc_ready (void)
+{
+    if (_init)
+    {
+        calculate_layout ();
+        draw_screen ();
+    }
+    _init = false;
+}
+
+
+void Niface::handle_ifc_init (M_ifc_init *M)
+{
+    if (_initdata) _initdata->recover ();
+    _initdata = M;
+}
+
+
+void Niface::handle_ifc_mcset (M_ifc_chconf *M)
+{
+    if (_mididata) _mididata->recover ();
+    _mididata = M;
+}
+
+
+void Niface::handle_ifc_retune (M_ifc_retune *M)
+{
+    // TODO: Show retuning message in status
+}
+
+
+void Niface::handle_ifc_grclr (M_ifc_ifelm *M)
+{
+    _ifelms [M->_group] = 0;
+    draw_screen ();
+}
+
+
+void Niface::handle_ifc_elclr (M_ifc_ifelm *M)
+{
+    _ifelms [M->_group] &= ~(1 << M->_ifelm);
+    draw_screen ();
+}
+
+
+void Niface::handle_ifc_elset (M_ifc_ifelm *M)
+{
+    _ifelms [M->_group] |= (1 << M->_ifelm);
+    draw_screen ();
+}
+
+
+void Niface::handle_ifc_elatt (M_ifc_ifelm *M)
+{
+    // TODO: Handle element attachment (retuning)
+    draw_screen ();
+}
+
+
+void Niface::rewrite_label (const char *p, char *dest, int maxlen)
+{
+    strncpy (dest, p, maxlen - 1);
+    dest[maxlen - 1] = 0;
+    
+    char *t = strstr (dest, "-$");
+    if (t) strcpy (t, t + 2);
+    else
+    {
+        t = strchr (dest, '$');
+        if (t) *t = ' ';
+    }
+}
+
+
+int Niface::get_stop_color (int group, int ifelm)
+{
+    if (!_initdata || group >= _initdata->_ngroup) return 4;
+    
+    if (ifelm >= _initdata->_groupd[group]._nifelm) return 4;
+    
+    int type = _initdata->_groupd[group]._ifelmd[ifelm]._type;
+    
+    // Color coding based on stop type
+    // TODO: Define proper type constants
+    switch (type)
+    {
+    case 1:  // Tremulant
+        return 1;  // Green
+    case 2:  // Coupler
+        return 2;  // Yellow/Brown
+    default:
+        return 4;  // Normal white
+    }
+}
+
+
+void Niface::get_stop_position (int group, int ifelm, int *y, int *x)
+{
+    // TODO: Calculate proper screen positions based on layout
+    *y = 5 + ifelm;
+    *x = 1 + (group % _groups_per_row) * _group_width;
+}

--- a/source/niface.h
+++ b/source/niface.h
@@ -28,6 +28,19 @@
 // Forward declaration
 class Niface;
 
+class NInputHandler : public H_thread
+{
+public:
+
+    NInputHandler (Niface *niface);
+    virtual ~NInputHandler (void);
+
+private:
+
+    virtual void thr_main (void);
+    Niface *_niface;
+};
+
 class NITCHandler : public H_thread
 {
 public:
@@ -45,6 +58,7 @@ private:
 class Niface : public Iface
 {
     friend class NITCHandler;
+    friend class NInputHandler;
     
 public:
 
@@ -68,12 +82,13 @@ private:
     void handle_ifc_elatt (M_ifc_ifelm *);
 
     // NCurses specific methods
-    void init_ncurses (void);
+    void init_ncurses_only (void);
     void cleanup_ncurses (void);
     void handle_input (void);
     void handle_input_msg (void);
     void handle_key (int ch);
     void draw_screen (void);
+    void draw_initial_screen (void);
     void draw_status (void);
     void draw_groups (void);
     void draw_cursor (void);
@@ -121,6 +136,7 @@ private:
     
     // ITC event handling
     NITCHandler     *_itc_handler;
+    NInputHandler   *_input_handler;
 };
 
 

--- a/source/niface.h
+++ b/source/niface.h
@@ -23,10 +23,29 @@
 
 #include <curses.h>
 #include "iface.h"
+#include "model.h"
+
+// Forward declaration
+class Niface;
+
+class NITCHandler : public H_thread
+{
+public:
+
+    NITCHandler (Niface *niface);
+    virtual ~NITCHandler (void);
+
+private:
+
+    virtual void thr_main (void);
+    Niface *_niface;
+};
 
 
 class Niface : public Iface
 {
+    friend class NITCHandler;
+    
 public:
 
     Niface (int ac, char *av []);
@@ -52,6 +71,8 @@ private:
     void init_ncurses (void);
     void cleanup_ncurses (void);
     void handle_input (void);
+    void handle_input_msg (void);
+    void handle_key (int ch);
     void draw_screen (void);
     void draw_status (void);
     void draw_groups (void);
@@ -73,6 +94,7 @@ private:
     bool            _stop;
     bool            _init;
     bool            _command_mode;
+    bool            _need_redraw;
     M_ifc_init     *_initdata;
     M_ifc_chconf   *_mididata;
     uint32_t        _ifelms [NGROUP];
@@ -89,6 +111,9 @@ private:
     char            _tempstr [64];
     char            _command_buffer [256];
     int             _command_pos;
+    
+    // ITC event handling
+    NITCHandler     *_itc_handler;
 };
 
 

--- a/source/niface.h
+++ b/source/niface.h
@@ -93,6 +93,7 @@ private:
 
     bool            _stop;
     bool            _init;
+    bool            _ready;
     bool            _command_mode;
     bool            _need_redraw;
     M_ifc_init     *_initdata;
@@ -111,6 +112,12 @@ private:
     char            _tempstr [64];
     char            _command_buffer [256];
     int             _command_pos;
+    
+    // Tuning state
+    bool            _has_tuning_stop;
+    int             _tuning_group;
+    int             _tuning_ifelm;
+    bool            _tuning_blink_state;
     
     // ITC event handling
     NITCHandler     *_itc_handler;

--- a/source/niface.h
+++ b/source/niface.h
@@ -1,0 +1,95 @@
+// ----------------------------------------------------------------------------
+//
+//  Copyright (C) 2003-2022 Fons Adriaensen <fons@linuxaudio.org>
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+
+
+#ifndef __NIFACE_H
+#define __NIFACE_H
+
+#include <curses.h>
+#include "iface.h"
+
+
+class Niface : public Iface
+{
+public:
+
+    Niface (int ac, char *av []);
+    virtual ~Niface (void);
+    virtual void stop (void);
+
+private:
+
+    virtual void thr_main (void);
+
+    void handle_mesg (ITC_mesg *);
+    void handle_time (void);
+    void handle_ifc_ready (void);
+    void handle_ifc_init (M_ifc_init *);
+    void handle_ifc_mcset (M_ifc_chconf *);
+    void handle_ifc_retune (M_ifc_retune *);
+    void handle_ifc_grclr (M_ifc_ifelm *);
+    void handle_ifc_elclr (M_ifc_ifelm *);
+    void handle_ifc_elset (M_ifc_ifelm *);
+    void handle_ifc_elatt (M_ifc_ifelm *);
+
+    // NCurses specific methods
+    void init_ncurses (void);
+    void cleanup_ncurses (void);
+    void handle_input (void);
+    void draw_screen (void);
+    void draw_status (void);
+    void draw_groups (void);
+    void draw_cursor (void);
+    void move_cursor (int dy, int dx);
+    void toggle_current_stop (void);
+    void recall_preset (int preset);
+    void store_preset (int preset);
+    void general_cancel (void);
+    void enter_command_mode (void);
+    void handle_resize (void);
+    
+    // Layout and display helpers
+    void calculate_layout (void);
+    void get_stop_position (int group, int ifelm, int *y, int *x);
+    int get_stop_color (int group, int ifelm);
+    void rewrite_label (const char *p, char *dest, int maxlen);
+
+    bool            _stop;
+    bool            _init;
+    bool            _command_mode;
+    M_ifc_init     *_initdata;
+    M_ifc_chconf   *_mididata;
+    uint32_t        _ifelms [NGROUP];
+    
+    // NCurses state
+    WINDOW         *_main_win;
+    WINDOW         *_status_win;
+    int             _cursor_group;
+    int             _cursor_ifelm;
+    int             _max_rows;
+    int             _max_cols;
+    int             _groups_per_row;
+    int             _group_width;
+    char            _tempstr [64];
+    char            _command_buffer [256];
+    int             _command_pos;
+};
+
+
+#endif

--- a/source/niface.h
+++ b/source/niface.h
@@ -87,7 +87,7 @@ private:
     void handle_input (void);
     void handle_input_msg (void);
     void handle_key (int ch);
-    void handle_resize_polling (void);
+    void handle_resize_from_signal (void);
     void draw_screen (void);
     void draw_initial_screen (void);
     void draw_status (void);

--- a/source/niface.h
+++ b/source/niface.h
@@ -87,6 +87,7 @@ private:
     void handle_input (void);
     void handle_input_msg (void);
     void handle_key (int ch);
+    void handle_resize_polling (void);
     void draw_screen (void);
     void draw_initial_screen (void);
     void draw_status (void);
@@ -98,7 +99,6 @@ private:
     void store_preset (int preset);
     void general_cancel (void);
     void enter_command_mode (void);
-    void handle_resize (void);
     
     // Layout and display helpers
     void calculate_layout (void);

--- a/source/niface.h
+++ b/source/niface.h
@@ -99,6 +99,9 @@ private:
     void store_preset (int preset);
     void general_cancel (void);
     void enter_command_mode (void);
+    void enter_midi_dialog (void);
+    void draw_midi_dialog (WINDOW *win, int cursor_row, int cursor_col, int cursor_section);
+    void toggle_midi_assignment (int row, int channel, int section);
     
     // Layout and display helpers
     void calculate_layout (void);


### PR DESCRIPTION
Create basic ncurses iface class structure

- Add niface.h with Niface class inheriting from Iface
- Implement basic ncurses initialization and cleanup
- Add message handling framework copied from Tiface
- Implement basic input handling for arrows, space, numbers, commands
- Add placeholder methods for all UI functionality
- Support command mode with / key for /quit
- Handle terminal resize events
- Basic window management (main + status windows)
- Color support for tremulants and couplers

The class builds successfully and integrates with CMake build system.
Core functionality framework is in place for further development.

Implement complete cursor navigation and control for NCurses interface

- Fix threading architecture: blocking input with separate ITC handler thread
- Add arrow key navigation with bounds checking and group wrapping
- Implement space bar stop toggling using M_ifc_ifelm messages
- Add preset recall (1-9) and storage (Shift+1-9) using M_ifc_preset
- Improve display layout with proper column alignment and stop colors
- Fix terminal resize handling and prevent crashes
- Add comprehensive message handling for model communication
- Update command line integration with -c flag for NCurses mode

Complete NCurses terminal UI with thread-safe responsive updates

Fix screen corruption and responsiveness issues in the NCurses interface:

1. Implement general_cancel function to push all stops via MT_IFC_GRCLR messages
2. Fix thread safety by ensuring only main UI thread calls draw_screen()
3. Make interface responsive with non-blocking input loop

Key fixes:
- Message handlers (handle_ifc_grclr, handle_ifc_ready, handle_ifc_elatt)
  now only set _need_redraw flag instead of calling draw_screen()
- Main loop uses non-blocking getch() and checks _need_redraw continuously
- Added 10ms sleep when idle to prevent excessive CPU usage
- Removed redundant draw_screen() calls from action functions

The NCurses interface now provides:
- Visual display of stops organized by groups with color coding
- Immediate responsive updates for preset recalls and general cancel
- Thread-safe screen rendering without corruption
- Full keyboard navigation and control

Implement enhanced tuning display with blinking stops and stable status bar

Create comprehensive tuning feedback system matching X11 GUI behavior:

**Tuning State Tracking:**
- Track _ready flag and currently tuning stop via MT_IFC_ELATT messages
- Handle MT_IFC_RETUNE as tuning-in-progress indication
- Clear tuning state when MT_IFC_READY received

**Visual Feedback:**
- Implement 4Hz blinking effect for currently tuning stop (like X11 GUI)
- Fixed-width status bar area (30 chars) to prevent layout jumping
- Right-aligned tuning status: "TUNING: <stop name>" with consistent positioning
- Normal stop display with tuning stop highlighted via A_BLINK

**User Interface:**
- Disable ALL stop interactions during tuning (toggle, presets, general cancel)
- Clear messaging: "Controls disabled" during tuning phase
- Stop name truncation to prevent overflow

**Technical Implementation:**
- Thread-safe: all display updates on main UI thread only
- Responsive timing loop with 250ms blink intervals
- Non-blocking input with proper CPU management
- Message handlers only set flags, never call draw functions directly

ncurses interface documentation

Creates user documentation for the NCurses terminal interface.

Replace polling with proper event-driven architecture in NCurses interface

Eliminates CPU-intensive usleep() polling by implementing clean event-driven
threading model:

- Main thread handles all events (input, model updates, timers) and does all
  ncurses drawing to ensure thread safety
- Input handler thread uses select() to wait for keyboard input, sends EV_INPUT
  to wake main thread
- Removed separate ITC handler thread - main thread processes FM_MODEL events
  directly to eliminate race conditions
- All screen updates happen atomically in main thread
- No polling delays, responsive input, stable display during initialization

Fix terminal resize handling in ncurses interface

- Replace crash-prone SIGWINCH handling with polling-based resize detection
- Use ioctl(TIOCGWINSZ) to directly query terminal dimensions every 250ms
- Properly resize ncurses windows with resizeterm(), wresize(), and mvwin()
- Recalculate group layout when terminal dimensions change
- Maintain thread safety by handling all resize operations in main thread

Resolves crashes that occurred when resizing terminal window while using
the ncurses (-t) interface.

Implement immediate terminal resize handling with self-pipe trick

Major improvements to ncurses terminal resize handling:

- SIGWINCH handler sets atomic flag and writes to self-pipe
- Input thread monitors both stdin and wake pipe with select()
- Main thread processes resize immediately when woken up
- No crashes due to clthreads spurious wakeup fix

- Self-pipe trick: SIGWINCH → pipe write → select() wake → instant processing
- Thread-safe coordination with std::atomic<bool> resize flag
- Direct terminal queries via ioctl(TIOCGWINSZ) for reliable sizing
- Proper ncurses integration with resizeterm(), wresize(), mvwin()

- get_event() when idle (infinite blocking)
- get_event_timed() only during tuning stop blinking
- Automatic timer management based on tuning state
- Dramatic CPU usage reduction when interface inactive

- Immediate resize response (no polling delays)
- Crash-free operation under all resize conditions
- Minimal CPU overhead when idle

Implement interactive MIDI configuration dialog in ncurses interface

Add comprehensive MIDI channel assignment functionality similar to X11 GUI:

Features:
- Interactive cursor navigation with arrow keys
- Space bar toggles MIDI channel assignments for keyboards/divisions/control
- Visual feedback with reverse video cursor and colored assignments
- Real-time configuration updates sent to model
- Proper filtering to show only divisions with swell pedals (expression control)

Interface:
- 'M' key provides immediate access to MIDI dialog
- '/midi' command also works for accessing dialog
- 'Q' or Ctrl-D exits dialog consistently with main interface
- Dialog automatically resizes and centers on terminal resize

Implementation:
- Column-based layout with channel headers (1-16)
- Sections for Keyboards, Divisions (swell-enabled only), and Control
- Proper bit manipulation for MIDI channel encoding:
  * Keyboards: 0x1000 + keyboard_id
  * Divisions: 0x2000 + (division_id << 8)
  * Control: 0x4000
- Live updates via M_ifc_chconf messages